### PR TITLE
Use a GitHub Action for the linter and further improve the CI/Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,15 @@ jobs:
           - os: macos-latest
             ext: dylib
             cc: cc
+            postfix: macos64
           - os: ubuntu-latest
             ext: so
             cc: cc
+            postfix: linux64
           - os: windows-latest
             ext: dll
             cc: x86_64-w64-mingw32-gcc
+            postfix: windows64s
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -47,3 +50,9 @@ jobs:
         run: |
             git status
             exit $(git status --porcelain=v1 2>/dev/null | grep -c src/parser.c)
+      - run: tar zcfv libtree-sitter-magik-${{ matrix.postfix }}.tar.gz libtree-sitter-magik.${{ matrix.ext }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: libtree-sitter-magik-${{ matrix.postfix }}
+          path: libtree-sitter-magik-${{ matrix.postfix }}.tar.gz
+          if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,4 +41,4 @@ jobs:
           ext: ${{ matrix.ext }}
           cc: ${{ matrix.cc }}
           postfix: ${{ matrix.postfix }}
-
+          check-parser: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,26 +33,12 @@ jobs:
           - os: windows-latest
             ext: dll
             cc: x86_64-w64-mingw32-gcc
-            postfix: windows64s
+            postfix: windows64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: sebastiaanspeck/build-tree-sitter-grammar@main
         with:
-          node-version: lts/*
-      - run: npm install
-      - name: tests
-        run: |
-          npm run-script build-test
-          ${{ matrix.cc }} -fPIC -c -Isrc/ src/parser.c -o parser.o
-          ${{ matrix.cc }} -fPIC -shared parser.o -o libtree-sitter-magik.${{ matrix.ext }}
-      - name: check unchanged parser.c
-        shell: bash
-        run: |
-            git status
-            exit $(git status --porcelain=v1 2>/dev/null | grep -c src/parser.c)
-      - run: tar zcfv libtree-sitter-magik-${{ matrix.postfix }}.tar.gz libtree-sitter-magik.${{ matrix.ext }}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: libtree-sitter-magik-${{ matrix.postfix }}
-          path: libtree-sitter-magik-${{ matrix.postfix }}.tar.gz
-          if-no-files-found: error
+          os: ${{ matrix.os }}
+          ext: ${{ matrix.ext }}
+          cc: ${{ matrix.cc }}
+          postfix: ${{ matrix.postfix }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,33 +12,55 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: lint
-        run: npm install && npm run lint
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm install
+      - name: Run linter
+        uses: tree-sitter/parser-test-action@v1.2
+        with:
+          lint: true
+          test-grammar: false
+          test-library: false
 
-  test:
+  build-and-test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
         include:
           - os: macos-latest
             ext: dylib
             cc: cc
-            postfix: macos64
           - os: ubuntu-latest
             ext: so
             cc: cc
-            postfix: linux64
           - os: windows-latest
             ext: dll
             cc: x86_64-w64-mingw32-gcc
-            postfix: windows64
     steps:
-      - uses: sebastiaanspeck/build-tree-sitter-grammar@main
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up NodeJS
+        uses: actions/setup-node@v4
         with:
-          os: ${{ matrix.os }}
-          ext: ${{ matrix.ext }}
-          cc: ${{ matrix.cc }}
-          postfix: ${{ matrix.postfix }}
-          check-parser: true
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm install
+      - name: Build and test
+        run: npm run-script build-test
+      - name: Check unchanged parser
+        shell: bash
+        run: |
+          git status
+          exit $(git status --porcelain=v1 2>/dev/null | grep -c src/parser.c)
+      - name: Build lib
+        run: |
+          ${{ matrix.cc }} -fPIC -c -Isrc/ src/parser.c -o parser.o
+          ${{ matrix.cc }} -fPIC -shared parser.o -o libtree-sitter-magik.${{ matrix.ext }}
+      - name: Upload lib
+        uses: actions/upload-artifact@v4
+        with:
+          name: libtree-sitter-magik-${{ runner.os }}
+          path: libtree-sitter-magik*
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+      - run: npm install
       - name: build
         run: |
-             npm install && npm run-script build-test
+             npm run-script build-test
              ${{ matrix.cc }} -fPIC -c -Isrc/ src/parser.c -o parser.o
              ${{ matrix.cc }} -fPIC -shared parser.o -o libtree-sitter-magik.${{ matrix.ext }}
              tar zcfv libtree-sitter-magik-${{ matrix.postfix }}.tar.gz libtree-sitter-magik.${{ matrix.ext }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,11 @@ jobs:
           path: libtree-sitter-magik
           pattern: libtree-sitter-magik*
           merge-multiple: true
+      - name: Zip artifacts
+        run: |
+          zip libtree-sitter-magik-macOS.zip libtree-sitter-magik.dylib
+          zip libtree-sitter-magik-Linux.zip libtree-sitter-magik.so
+          zip libtree-sitter-magik-Windows.zip libtree-sitter-magik.dll
       - uses: softprops/action-gh-release@v2
         with:
-          files: |
-            libtree-sitter-magik/*
+          files: libtree-sitter-magik-*.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,22 +26,12 @@ jobs:
             cc: x86_64-w64-mingw32-gcc
             postfix: windows64
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: sebastiaanspeck/build-tree-sitter-grammar@main
         with:
-          node-version: lts/*
-      - run: npm install
-      - name: build
-        run: |
-             npm run-script build-test
-             ${{ matrix.cc }} -fPIC -c -Isrc/ src/parser.c -o parser.o
-             ${{ matrix.cc }} -fPIC -shared parser.o -o libtree-sitter-magik.${{ matrix.ext }}
-             tar zcfv libtree-sitter-magik-${{ matrix.postfix }}.tar.gz libtree-sitter-magik.${{ matrix.ext }}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: libtree-sitter-magik-${{ matrix.postfix }}
-          path: libtree-sitter-magik-${{ matrix.postfix }}.tar.gz
-          if-no-files-found: error
+          os: ${{ matrix.os }}
+          ext: ${{ matrix.ext }}
+          cc: ${{ matrix.cc }}
+          postfix: ${{ matrix.postfix }}
 
   publish:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,35 +6,45 @@ on:
       - '*.*.*'
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ${{ matrix.os }}
     continue-on-error: true
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
         include:
           - os: macos-latest
             ext: dylib
             cc: cc
-            postfix: macos64
           - os: ubuntu-latest
             ext: so
             cc: cc
-            postfix: linux64
           - os: windows-latest
             ext: dll
             cc: x86_64-w64-mingw32-gcc
-            postfix: windows64
     steps:
-      - uses: sebastiaanspeck/build-tree-sitter-grammar@main
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up NodeJS
+        uses: actions/setup-node@v4
         with:
-          os: ${{ matrix.os }}
-          ext: ${{ matrix.ext }}
-          cc: ${{ matrix.cc }}
-          postfix: ${{ matrix.postfix }}
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm install
+      - name: Build and test
+        run: npm run-script build-test
+      - name: Build lib
+        run: |
+          ${{ matrix.cc }} -fPIC -c -Isrc/ src/parser.c -o parser.o
+          ${{ matrix.cc }} -fPIC -shared parser.o -o libtree-sitter-magik.${{ matrix.ext }}
+      - name: Upload lib
+        uses: actions/upload-artifact@v4
+        with:
+          name: libtree-sitter-magik-${{ runner.os }}
+          path: libtree-sitter-magik*
+          if-no-files-found: error
 
   publish:
-    needs: build
+    needs: build-and-test
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -44,7 +54,7 @@ jobs:
           path: libtree-sitter-magik
           pattern: libtree-sitter-magik*
           merge-multiple: true
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@v2
         with:
           files: |
             libtree-sitter-magik/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tree-sitter-magik",
-	"version": "0.0.0",
+	"version": "0.0.1",
 	"description": "Magik grammar for tree-sitter",
 	"main": "bindings/node",
 	"keywords": [


### PR DESCRIPTION
Use a GitHub Action for the linter. Tried to use the same action for building, but that would require us to upload unwanted files to track in Git like `package-lock.json` and `Cargo.toml`.

**Other changes**:
- When running the CI-workflow and if the parser.c did not change, this will upload the artifacts as well to use them as snapshots between releases.
- Bumped the package version to match the latest tag
- Changed the artifacts to upload the `.dll`, `.dylib` and `.so` directly without having a `tar.gz` to unzip.

Refs:
- https://github.com/sebastiaanspeck/tree-sitter-magik/actions/runs/8245637324
- https://github.com/sebastiaanspeck/tree-sitter-magik/actions/runs/8245716273
- https://github.com/sebastiaanspeck/tree-sitter-magik/releases/tag/0.0.1-SNAPSHOT (will be deleted after this PR is merged)