### PR TITLE
Fix case for `c`/`x` flags

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -313,7 +313,7 @@ module.exports = grammar({
       ),
 
     // /<pattern>/<flags>
-    regex_literal: $ => token(/\/.*?\/[qisdlmuCX]*/),
+    regex_literal: $ => token(/\/.*?\/[qisdlmucx]*/),
 
     call: $ =>
       prec.right(PREC.CALL,

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -2405,7 +2405,7 @@
       "type": "TOKEN",
       "content": {
         "type": "PATTERN",
-        "value": "\\/.*?\\/[qisdlmuCX]*"
+        "value": "\\/.*?\\/[qisdlmucx]*"
       }
     },
     "call": {

--- a/src/parser.c
+++ b/src/parser.c
@@ -7656,8 +7656,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_regex_literal);
       ADVANCE_MAP(
         '/', 519,
-        'C', 519,
-        'X', 519,
+        'c', 519,
         'd', 519,
         'i', 519,
         'l', 519,
@@ -7665,6 +7664,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         'q', 519,
         's', 519,
         'u', 519,
+        'x', 519,
       );
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(36);

--- a/src/parser.c
+++ b/src/parser.c
@@ -7649,8 +7649,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
       ACCEPT_TOKEN(sym_regex_literal);
       ADVANCE_MAP(
         '/', 519,
-        'C', 519,
-        'X', 519,
+        'c', 519,
         'd', 519,
         'i', 519,
         'l', 519,
@@ -7658,6 +7657,7 @@ static bool ts_lex(TSLexer *lexer, TSStateId state) {
         'q', 519,
         's', 519,
         'u', 519,
+        'x', 519,
       );
       if (lookahead != 0 &&
           lookahead != '\n') ADVANCE(36);

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -228,9 +228,17 @@ regular expression
 
 /[aB]*c,/im
 
+/garçon/c
+
+/a.b/x
+
 --------------------------------------------------------------------------------
 
 (source_file
+  (fragment
+    (regex_literal))
+  (fragment
+    (regex_literal))
   (fragment
     (regex_literal))
   (fragment


### PR DESCRIPTION
Bug:
```magik
Magik> /abc/C
**** Error (parser_error): on line 1
/abc/C
     ^
Missing end of statement


Magik> /abc/c
a sw_regexp(obj#1099385723) 

Magik> /abc/X
**** Error (parser_error): on line 1
/abc/X
     ^
Missing end of statement


Magik> /abc/x
a sw_regexp(obj#896682100) 
```

Example:
```
Magik> /\w+/.matches?("café")
False 
Magik> /\w+/c.matches?("café")
True 
Magik> /a.b/.matches?("a" + %return + "b")
False 
Magik> /a.b/x.matches?("a" + %return + "b")
True 
```

<img width="941" height="736" alt="image" src="https://github.com/user-attachments/assets/bb39f7c5-a927-4389-8995-505ecb1a3744" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated supported regex flag variants accepted after regex literals, adjusting which flag characters are recognized (case-specific variants) to improve compatibility with expected syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->